### PR TITLE
Fix for issue #1 parent process exits timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.o
 killjoy
+.vscode


### PR DESCRIPTION
Back when I first wrote this I redefined the `WIFSIGNALED` macro to only
use the negated `WIFEXITED` and `WIFSTOPPED` (I can only guess that it
was some attempt to be clever - though I was running HPC at the time and
signalling from the scheduler can get messy) for it's evaluation of
whether or not it received a signal to terminate.  This actually still
works as intended on older versions of linux, gcc, and libc (compiled
and ran fine on linux 4.4.0, gcc-4.8 and libc-2.19) but interestingly
enough, on my new Ubuntu 19.04 install with linux 5.0.0, gcc-8.3 and
libc-2.29, `WIFEXITED(status)` always returns true when evaluating the
status returned by waitpid.  They are evaluated the same in both
environments `/usr/include/x86_64-linux-gnu/bits/waitstatus.h` so it's
not that the signals changed. I suspected that since I was using a bash
script to test and there were child processes associated with that
script, that WIFEXITED may have been catching the signal of the sleep
command exiting cleanly however, that did not appear to be the case (and
if was the case would be wreaking havok on the world)  At this point
evaluating `!WIFSIGNALED(status)` returns the appropriate response.

Updated readme, version bump. Closes #1 